### PR TITLE
feat: add paste button, move copied text location to avoid wrapping

### DIFF
--- a/src/components/MyMenu.vue
+++ b/src/components/MyMenu.vue
@@ -119,5 +119,8 @@ function onSelectIME(value: string) {
         </n-tooltip>
       </n-button-group>
     </n-space>
+    <n-space>
+      <span id="copied"></span>
+    </n-space>
   </n-flex>
 </template>

--- a/src/components/SimpleKeyboard.vue
+++ b/src/components/SimpleKeyboard.vue
@@ -9,7 +9,7 @@
 import { ref, h, render, computed, defineComponent, nextTick } from "vue"
 import Keyboard from "simple-keyboard";
 import "simple-keyboard/build/css/index.css";
-import { useOsTheme, NIcon } from "naive-ui"
+import { useOsTheme } from "naive-ui"
 import { currentTheme } from '../util'
 
 const KeyboardHideOutlinedSvg = `<svg style="width:24px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24"><path d="M20 3H4c-1.1 0-1.99.9-1.99 2L2 15c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 12H4V5h16v10zm-9-9h2v2h-2zm0 3h2v2h-2zM8 6h2v2H8zm0 3h2v2H8zM5 9h2v2H5zm0-3h2v2H5zm3 6h8v2H8zm6-3h2v2h-2zm0-3h2v2h-2zm3 3h2v2h-2zm0-3h2v2h-2zm-5 17l4-4H8z" fill="currentColor"></path></svg>`


### PR DESCRIPTION
## 更新内容
- 添加粘贴按钮 (fix #5)
- 将已复制文字移至页面右上角，以免导致换行 (fix #6)
  （输入框下方按键栏的空间也快不够用了，希望能收集到一些界面改进的建议）

![Screenshot 2025-05-22 at 11 04 10 pm](https://github.com/user-attachments/assets/464b9feb-5fe1-4713-8fa5-32a116ac3a97)
![Screenshot 2025-05-22 at 11 05 49 pm](https://github.com/user-attachments/assets/ab67dce8-59d4-4eb3-8325-83729cee65c2)